### PR TITLE
Disable user-select when the item is being dragged

### DIFF
--- a/src/GridItem.vue
+++ b/src/GridItem.vue
@@ -1,7 +1,7 @@
 <template>
     <div ref="item"
          class="vue-grid-item"
-         :class="{ 'vue-resizable' : resizable, 'resizing' : isResizing, 'vue-draggable-dragging' : isDragging, 'cssTransforms' : useCssTransforms, 'render-rtl' : renderRtl }"
+         :class="{ 'vue-resizable' : resizable, 'resizing' : isResizing, 'vue-draggable-dragging' : isDragging, 'cssTransforms' : useCssTransforms, 'render-rtl' : renderRtl, 'disable-userselect': isDragging }"
          :style="style"
     >
         <slot></slot>
@@ -74,6 +74,10 @@
         background-origin: content-box;
         cursor: sw-resize;
         right: auto;
+    }
+    
+    .vue-grid-item.disable-userselect {
+        user-select: none;
     }
 </style>
 <script>


### PR DESCRIPTION
Disable `user-select` on `.vue-grid-item` when it's being dragged. If the user selects text inside `.vue-grid-item` and starts moving it, that selection will prevent him from dragging the item.

Setting `user-select` to `none` fixes the issue.